### PR TITLE
Make font_bits() non-static to fix linking errors

### DIFF
--- a/v6.x/cjktty-6.12.63.patch
+++ b/v6.x/cjktty-6.12.63.patch
@@ -666,7 +666,7 @@ index dc5ad3fcc..d512ceeb8 100644
 +		return scr_readw(s + 1);
 +}
 +
-+static u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
++u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
 +	struct fbcon_ops *ops)
 +{
 +	u8 *src;

--- a/v6.x/cjktty-6.19.patch
+++ b/v6.x/cjktty-6.19.patch
@@ -230,7 +230,7 @@ index 085ffb44c..9dfed9687 100644
 +		return scr_readw(s + 1);
 +}
 +
-+static u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
++u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
 +	struct fbcon_par *par)
 +{
 +	u8 *src;


### PR DESCRIPTION
在尝试使用`cjktty-6.12.63.patch`编译相应版本的内核时，出现：
```
ld: drivers/video/fbdev/core/fbcon_cw.o: in function `cw_putcs_aligned':
/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_cw.c:95: undefined reference to `font_bits'
ld: drivers/video/fbdev/core/fbcon_cw.o: in function `cw_cursor':
/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_cw.c:225: undefined reference to `font_bits'
ld: drivers/video/fbdev/core/fbcon_ud.o: in function `ud_putcs_aligned':
/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_ud.c:97: undefined reference to `font_bits'
ld: drivers/video/fbdev/core/fbcon_ud.o: in function `ud_putcs_unaligned':
/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_ud.c:132: undefined reference to `font_bits'
ld: drivers/video/fbdev/core/fbcon_ud.o: in function `ud_cursor':
/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_ud.c:273: undefined reference to `font_bits'
ld: drivers/video/fbdev/core/fbcon_ccw.o:/home/zlk/kernel/linux-6.12.74/drivers/video/fbdev/core/fbcon_ccw.c:110: more undefined references to `font_bits' follow
make[2]: *** [scripts/Makefile.vmlinux:34：vmlinux] 错误 1
make[1]: *** [/home/zlk/kernel/linux-6.12.74/Makefile:1180：vmlinux] 错误 2
make: *** [Makefile:224：__sub-make] 错误 2
```

经检查，问题出在对于`bitblit.c`的补丁部分：
`+static u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,`
其中的`static`修饰符使其他文件无法找到`font_bits`

删除`static`后，编译正常

该问题影响`cjktty-6.12.63.patch`与`cjktty-6.19.patch`，其余版本均无`static`